### PR TITLE
auto-pts enhancements - many auto-pts instances on one machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
    * [Introduction](#introduction)
    * [Architecture](#architecture)
+   * [Linux Prerequisites](#linux-prerequisites)
    * [Windows Prerequisites](#windows-prerequisites)
-   * [Generating Interop Assembly](#generating-interop-assembly)
    * [PTS Workspace Setup](#pts-workspace-setup)
    * [Running in Client/Server Mode](#running-in-clientserver-mode)
-   * [Running Test Script on Windows](#running-test-script-on-windows)
    * [Running AutoPTSClientBot](#running-autoptsclientbot)
+   * [Zephyr with AutoPTS step-by-step setup tutorial](#zephyr-with-autopts-step-by-step-setup-tutorial)
    * [IRC Channel on freenode.net](#irc-channel-on-freenodenet)
 
 # Introduction
@@ -34,6 +34,8 @@ Over 460 test cases have been automated for Zephyr OS and Mynewt OS which reduce
 
 **Bluetooth Test Protocol (BTP)**: Used to communicate with the IUT. See `doc/btp_spec.txt`
 
+Update: Now for Zephyr you can run auto-pts client and server both under Windows 10: [Zephyr with AutoPTS step-by-step setup tutorial](#zephyr-with-autopts-step-by-step-setup-tutorial)
+
 # Linux Prerequisites
 
 1. `socat` that is used to transfer BTP data stream from UART's tty file.
@@ -43,6 +45,10 @@ Over 460 test cases have been automated for Zephyr OS and Mynewt OS which reduce
 2. Additionally, install required Python modules with:
 
         python3 -m pip install --user -r autoptsclient_requirements.txt
+
+3. Download and install latest nrftools (version >= 10.12.1) from site
+   https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Command-Line-Tools/Download
+   and run default install.
 
 # Windows Prerequisites
 
@@ -126,7 +132,8 @@ This may contain few sections:
 - `name` - AutoPTS project name
 * `auto_pts` - AutoPTS configuration
     - `server_ip` - AutoPTSServer IP address
-    - `client_port` - local AutoPTSClient port
+    - `cli_port` - AutoPTSClient port(s)
+    - `srv_port` - AutoPTSServer port(s)
     - `project_path` - path to project source directory
     - `workspace` - PTS workspace path to be used
     - `board` - IUT used. Currently nrf52 is supported only
@@ -162,6 +169,16 @@ Install required Python modules with:
 **Usage**
 
     ./autoptsclient_bot.py
+
+# Zephyr with AutoPTS step-by-step setup tutorial
+Check out the guide how to set up AutoPTS for Zephyr + nRF52 under:
+- Linux + Windows 10 virtual machine
+
+  https://github.com/zephyrproject-rtos/zephyr/blob/main/doc/guides/bluetooth/autopts/autopts-linux.rst
+
+- Windows 10
+
+  https://github.com/zephyrproject-rtos/zephyr/blob/main/doc/guides/bluetooth/autopts/autopts-win10.rst
 
 # IRC Channel on freenode.net
 

--- a/autoptsclient-zephyr.py
+++ b/autoptsclient-zephyr.py
@@ -22,6 +22,7 @@ import sys
 import ctypes
 import argparse
 from distutils.spawn import find_executable
+import _locale
 
 import autoptsclient_common as autoptsclient
 import ptsprojects.zephyr as autoprojects
@@ -102,6 +103,12 @@ def parse_args():
 
 def main():
     """Main."""
+
+    # Workaround for logging error: "UnicodeEncodeError: 'charmap' codec can't
+    # encode character '\xe6' in position 138: character maps to <undefined>",
+    # which occurs under Windows with default encoding other than cp1252
+    # each time log() is called.
+    _locale._getdefaultlocale = (lambda *args: ['en_US', 'utf8'])
 
     if have_admin_rights():  # root privileges are not needed
         sys.exit("Please do not run this program as root.")

--- a/autoptsclient-zephyr.py
+++ b/autoptsclient-zephyr.py
@@ -38,10 +38,12 @@ def check_args(args):
     qemu_bin = autoprojects.iutctl.QEMU_BIN
     tty_file = args.tty_file
     kernel_image = args.kernel_image
-    ip_addr = args.ip_addr
 
-    if not ip_addr:
-        sys.exit("Server IP address not specified!")
+    if not args.ip_addr:
+        args.ip_addr = ['127.0.0.1'] * len(args.srv_port)
+
+    if not args.local_addr:
+        args.local_addr = ['127.0.0.1'] * len(args.cli_port)
 
     if tty_file:
         if tty_file.startswith("COM"):

--- a/autoptsclient_bot.py
+++ b/autoptsclient_bot.py
@@ -19,10 +19,13 @@ import os
 import sys
 import schedule
 import time
+import _locale
 
 from bot.config import BotProjects
 from bot.zephyr import main as zephyr
 from bot.mynewt import main as mynewt
+from winutils import have_admin_rights
+
 
 # TODO Find more sophisticated way
 weekdays2schedule = {
@@ -42,6 +45,12 @@ project2main = {
 
 
 def main():
+    # Workaround for logging error: "UnicodeEncodeError: 'charmap' codec can't
+    # encode character '\xe6' in position 138: character maps to <undefined>",
+    # which occurs under Windows with default encoding other than cp1252
+    # each time log() is called.
+    _locale._getdefaultlocale = (lambda *args: ['en_US', 'utf8'])
+
     for project in BotProjects:
         # TODO Solve the issue of overlapping jobs
         if 'scheduler' in project:
@@ -57,7 +66,7 @@ def main():
 
 
 if __name__ == "__main__":
-    if os.geteuid() == 0:  # root privileges are not needed
+    if have_admin_rights():  # root privileges are not needed
         print("Please do not run this program as root.")
         sys.exit(1)
 

--- a/autoptsclient_common.py
+++ b/autoptsclient_common.py
@@ -417,24 +417,21 @@ def init_pts(args, tc_db_table_name=None):
 
     init_logging()
 
-    local_port = CLIENT_PORT
-
-    for server_addr, local_addr in zip(args.ip_addr, args.local_addr):
+    for server_addr, local_addr, server_port, local_port \
+            in zip(args.ip_addr, args.local_addr, args.srv_port, args.cli_port):
         if AUTO_PTS_LOCAL:
             proxy = FakeProxy()
         else:
             proxy = xmlrpc.client.ServerProxy(
-                "http://{}:{}/".format(server_addr, SERVER_PORT),
+                "http://{}:{}/".format(server_addr, server_port),
                 allow_none=True,)
 
-        print("(%r) Starting PTS %s ..." % (id(proxy), server_addr))
+        print("(%r) Starting PTS %s:%s ..." % (id(proxy), server_addr, server_port))
 
         thread = threading.Thread(target=init_pts_thread_entry,
                                   args=(proxy, local_addr, local_port, args.workspace,
                                         args.bd_addr, args.enable_max_logs))
         thread.start()
-
-        local_port += 1
 
         proxy_list.append(proxy)
         thread_list.append(thread)
@@ -957,3 +954,9 @@ class CliParser(argparse.ArgumentParser):
         self.add_argument("-r", "--retry", type=int, default=0,
                           help="Repeat test if failed. Parameter specifies "
                                "maximum repeat count per test")
+
+        self.add_argument("-S", "--srv_port", type=int, nargs="+", default=[SERVER_PORT],
+                          help="Specify the server port number")
+
+        self.add_argument("-C", "--cli_port", type=int, nargs="+", default=[CLIENT_PORT],
+                          help="Specify the client port number")

--- a/autoptsclient_common.py
+++ b/autoptsclient_common.py
@@ -312,12 +312,12 @@ def get_my_ip_address():
 get_my_ip_address.cached_address = None
 
 
-def init_logging():
+def init_logging(tag=""):
     """Initialize logging"""
     script_name = os.path.basename(sys.argv[0])  # in case it is full path
     script_name_no_ext = os.path.splitext(script_name)[0]
 
-    log_filename = "%s.log" % (script_name_no_ext,)
+    log_filename = "%s%s.log" % (script_name_no_ext, tag)
     format = ("%(asctime)s %(name)s %(levelname)s %(filename)-25s "
               "%(lineno)-5s %(funcName)-25s : %(message)s")
 
@@ -415,7 +415,7 @@ def init_pts(args, tc_db_table_name=None):
     proxy_list = []
     thread_list = []
 
-    init_logging()
+    init_logging('_' + '_'.join(str(x) for x in args.cli_port))
 
     for server_addr, local_addr, server_port, local_port \
             in zip(args.ip_addr, args.local_addr, args.srv_port, args.cli_port):
@@ -877,8 +877,9 @@ def run_test_cases(ptses, test_case_instances, args):
 
         return True
 
+    ports_str = '_'.join(str(x) for x in args.cli_port)
     now = datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-    session_log_dir = 'logs/' + now
+    session_log_dir = 'logs/cli_port_' + ports_str + '/' + now
     try:
         os.makedirs(session_log_dir)
     except OSError as e:

--- a/autoptsserver.py
+++ b/autoptsserver.py
@@ -125,7 +125,7 @@ def main():
     script_name = os.path.basename(sys.argv[0])  # in case it is full path
     script_name_no_ext = os.path.splitext(script_name)[0]
 
-    log_filename = "%s.log" % (script_name_no_ext,)
+    log_filename = "%s_%s.log" % (script_name_no_ext, str(args.srv_port))
     format = ("%(asctime)s %(name)s %(levelname)s : %(message)s")
 
     logging.basicConfig(format=format,

--- a/autoptsserver.py
+++ b/autoptsserver.py
@@ -28,6 +28,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+import argparse
 import os
 import wmi
 import sys
@@ -92,9 +93,34 @@ class PyPTSWithXmlRpcCallback(ptscontrol.PyPTS):
         self.client_xmlrpc_proxy = None
 
 
+class SvrArgumentParser(argparse.ArgumentParser):
+    def __init__(self, description):
+        argparse.ArgumentParser.__init__(self, description=description)
+
+        self.add_argument("-S", "--srv_port", type=int, default=SERVER_PORT,
+                          help="Specify the server port number")
+
+    def check_args(self, args):
+        """Sanity check command line arguments"""
+
+        srv_port = args.srv_port
+        if srv_port:
+            if not 49152 <= srv_port <= 65535:
+                sys.exit("Invalid server port number=%s, expected range <49152,65535> " % (srv_port,))
+        else:
+            sys.exit("%s is needed but not found!" % (srv_port,))
+
+    def parse_args(self, args=None, namespace=None):
+        args = super().parse_args()
+        self.check_args(args)
+        return args
+
+
 def main():
     """Main."""
     winutils.exit_if_admin()
+
+    args = SvrArgumentParser("PTS automation server").parse_args()
 
     script_name = os.path.basename(sys.argv[0])  # in case it is full path
     script_name_no_ext = os.path.splitext(script_name)[0]
@@ -115,9 +141,9 @@ def main():
     pts = PyPTSWithXmlRpcCallback()
     print("OK")
 
-    print("Serving on port {} ...".format(SERVER_PORT))
+    print("Serving on port {} ...".format(args.srv_port))
 
-    server = xmlrpc.server.SimpleXMLRPCServer(("", SERVER_PORT), allow_none=True)
+    server = xmlrpc.server.SimpleXMLRPCServer(("", args.srv_port), allow_none=True)
     server.register_instance(pts)
     server.register_introspection_functions()
     server.serve_forever()

--- a/bot/config.py.zephyr.sample
+++ b/bot/config.py.zephyr.sample
@@ -26,9 +26,10 @@ z = zephyr_nrf52 = {
 # AutoPTS configuration
 # ****************************************************************************
 z['auto_pts'] = {
-    'server_ip': ['192.168.0.2'],
-    'client_port': 65001,
-    'local_ip' : ['192.168.0.100'],
+    # 'server_ip': ['192.168.3.2', '192.168.3.2'],
+    # 'local_ip': ['192.168.3.2', '192.168.3.2'],
+    'cli_port': [65001, 65003],
+    'srv_port': [65000, 65002],
     'project_path': '/path/to/project',
     'workspace': 'zephyr-master',
     'board': 'nrf52',
@@ -84,6 +85,12 @@ z['gdrive'] = {
 # ****************************************************************************
 
 z['iut_config'] = {
+    "default": {  # Default west build without option -- -DCONF_FILE=<file.conf>
+        "test_cases": [
+            'MESH'
+        ],
+    },
+
     "prj.conf": {},  # Default config file name
 
     "enforce_mitm.conf": {

--- a/ptscontrol.py
+++ b/ptscontrol.py
@@ -47,6 +47,7 @@ import xmlrpc.client
 import pythoncom
 import ptsprojects.ptstypes as ptstypes
 import ctypes
+from pathlib import Path
 
 log = logging.debug
 
@@ -511,8 +512,11 @@ class PyPTS:
         workspace_dir = os.path.dirname(workspace_path)
         workspace_name = os.path.basename(workspace_path)
 
+        temp_workspace_dir = os.path.join(workspace_dir, "_" + self.get_bluetooth_address())
+        Path(temp_workspace_dir).mkdir(parents=False, exist_ok=True)
+
         self._temp_workspace_path = \
-            os.path.join(workspace_dir, "temp_" + workspace_name)
+            os.path.join(temp_workspace_dir, "temp_" + workspace_name)
         shutil.copy2(workspace_path, self._temp_workspace_path)
         log("Using temporary workspace: %s", self._temp_workspace_path)
 

--- a/ptsprojects/testcase.py
+++ b/ptsprojects/testcase.py
@@ -733,8 +733,14 @@ class TestCase(PTSCallback):
         if os.path.exists(subproc_path):
             log("%s, run pre test case script" % self.post_run.__name__)
             self.lf_subproc = open(subproc_dir + "sp_pre_stdout.log", "w")
-            subproc_cmd = " ".join(
-                [subproc_path, self.project_name, self.name])
+
+            if sys.platform == "win32":
+                subproc_cmd = " ".join(["python", repr(subproc_path),
+                                        self.project_name, self.name])
+            else:
+                subproc_cmd = " ".join(
+                    [subproc_path, self.project_name, self.name])
+
             self.tc_subproc = subprocess.Popen(shlex.split(subproc_cmd),
                                                shell=False,
                                                stdin=subprocess.PIPE,
@@ -790,8 +796,14 @@ class TestCase(PTSCallback):
         if os.path.exists(subproc_path):
             log("%s, run post test case script" % self.post_run.__name__)
             self.lf_subproc = open(subproc_dir + "sp_post_stdout.log", "w")
-            subproc_cmd = " ".join(
-                [subproc_path, self.project_name, self.name])
+
+            if sys.platform == "win32":
+                subproc_cmd = " ".join(["python", repr(subproc_path),
+                                        self.project_name, self.name])
+            else:
+                subproc_cmd = " ".join(
+                    [subproc_path, self.project_name, self.name])
+
             self.tc_subproc = subprocess.Popen(shlex.split(subproc_cmd),
                                                shell=False,
                                                stdin=subprocess.PIPE,

--- a/ptsprojects/zephyr/iutctl.py
+++ b/ptsprojects/zephyr/iutctl.py
@@ -75,7 +75,7 @@ class ZephyrCtl:
         self.test_case = None
         self.rtt2pty_process = None
         self.iut_log_file = None
-        self.btp_address = BTP_ADDRESS
+        self.btp_address = BTP_ADDRESS + self.debugger_snr
 
         if use_rtt2pty:
             self.rtt2pty = RTT2PTY()

--- a/ptsprojects/zephyr/iutctl.py
+++ b/ptsprojects/zephyr/iutctl.py
@@ -13,6 +13,7 @@
 # more details.
 #
 
+import re
 import socket
 import subprocess
 import os
@@ -58,10 +59,12 @@ class ZephyrCtl:
             self.__class__, self.__init__.__name__, kernel_image, tty_file,
             board_name)
 
+        self.debugger_snr = None
         self.kernel_image = kernel_image
         self.tty_file = tty_file
 
         if self.tty_file and board_name:  # DUT is a hardware board, not QEMU
+            self.get_debugger_snr()
             self.board = Board(board_name, kernel_image, self)
         else:  # DUT is QEMU or a board that won't be reset
             self.board = None
@@ -78,6 +81,23 @@ class ZephyrCtl:
             self.rtt2pty = RTT2PTY()
         else:
             self.rtt2pty = None
+
+    def get_debugger_snr(self):
+        debuggers = subprocess.Popen('nrfjprog --com',
+                                     shell=True,
+                                     stdout=subprocess.PIPE
+                                     ).stdout.read().decode()
+
+        if sys.platform == "win32":
+            COM = "COM" + str(int(self.tty_file["/dev/ttyS".__len__():]) + 1)
+            reg = "[0-9]+(?=\s+" + COM + ".+)"
+        else:
+            reg = "[0-9]+(?=\s+" + self.tty_file + ".+)"
+
+        try:
+            self.debugger_snr = re.findall(reg, debuggers)[0]
+        except:
+            sys.exit("No debuggers associated with the device found")
 
     def start(self, test_case):
         """Starts the Zephyr OS"""
@@ -239,8 +259,8 @@ class Board:
 
         self.name = board_name
         self.kernel_image = kernel_image
-        self.reset_cmd = self.get_reset_cmd()
         self.iutctl = iutctl
+        self.reset_cmd = self.get_reset_cmd()
 
     def reset(self):
         """Reset HW DUT board with openocd
@@ -326,7 +346,7 @@ class Board:
         Dependency: nRF5x command line tools
 
         """
-        return 'nrfjprog -f nrf52 -r'
+        return 'nrfjprog -f nrf52 -r -s ' + self.iutctl.debugger_snr
 
     def _get_reset_cmd_reel(self):
         """Return reset command for Reel_Board DUT
@@ -335,6 +355,7 @@ class Board:
 
         """
         return 'pyocd cmd -c reset'
+
 
 def get_iut():
     return ZEPHYR

--- a/ptsprojects/zephyr/pre_tc.py
+++ b/ptsprojects/zephyr/pre_tc.py
@@ -24,32 +24,16 @@ import signal
 PROFILE = None
 TEST_CASE = None
 
-BTMON_PROC = None
-BTMON_LOG = None
-# XXX: Fill me - btmon path example: /home/user/bluez/monitor/btmon
-BTMON_PATH = 'btmon'
-
 # XXX: Fill me - logs dir example: /home/user/btmon_logs/
 LOGS_DIR = 'iut_logs/'
 
 
 def cleanup():
-    if BTMON_PROC:
-        BTMON_PROC.terminate()
-
-        BTMON_PROC.wait()
-
-
-def run_btmon():
-    global BTMON_PROC, TEST_CASE
-
-    TEST_CASE = TEST_CASE.replace("/", "-")
-
-    BTMON_PROC = subprocess.Popen([BTMON_PATH, "-w", LOGS_DIR + PROFILE + "/" +
-                                   TEST_CASE], shell=False)
+    pass
 
 
 def main():
+    return  # Remove this if any subprocess is implemented
     global PROFILE, TEST_CASE
 
     atexit.register(cleanup)
@@ -60,15 +44,13 @@ def main():
     if not os.path.exists(LOGS_DIR + PROFILE):
         os.makedirs(LOGS_DIR + PROFILE)
 
-    run_btmon()
+    # Start some subprocess here
 
     while True:
         line = sys.stdin.readline()
 
         if line == "#close\n":
-            BTMON_PROC.terminate()
-            BTMON_PROC.wait()
-
+            # Terminate subprocess here
             break
 
 

--- a/pybtp/iutctl_common.py
+++ b/pybtp/iutctl_common.py
@@ -264,8 +264,12 @@ class RTT2PTY:
         self.log_filename = None
         self.log_file = None
 
-    def _start_rtt2pty_proc(self):
-        self.rtt2pty_process = subprocess.Popen('rtt2pty',
+    def _start_rtt2pty_proc(self, debugger_snr=None):
+        cmd = ['rtt2pty']
+        if debugger_snr:
+            cmd.append('-s ' + debugger_snr)
+
+        self.rtt2pty_process = subprocess.Popen(cmd,
                                                 shell=False,
                                                 stdout=subprocess.PIPE,
                                                 stderr=subprocess.PIPE)
@@ -294,10 +298,9 @@ class RTT2PTY:
             file.write(decoded)
             file.flush()
 
-
-    def start(self, log_filename):
+    def start(self, log_filename, debugger_snr=None):
         self.log_filename = log_filename
-        self.pty_name = self._start_rtt2pty_proc()
+        self.pty_name = self._start_rtt2pty_proc(debugger_snr)
 
         self.serial = serial.Serial(self.pty_name, 115200, timeout=0)
         self.stop_thread.clear()
@@ -321,3 +324,25 @@ class RTT2PTY:
             self.rtt2pty_process.send_signal(signal.SIGINT)
             self.rtt2pty_process.wait()
             self.rtt2pty_process = None
+
+
+class BTMON:
+    def __init__(self):
+        self.btmon_process = None
+        self.pty_name = None
+        self.log_file = None
+
+    def start(self, log_file, debugger_snr):
+        self.log_file = log_file
+        cmd = ['btmon', '-J', 'NRF52,' + debugger_snr, '-w', self.log_file]
+
+        self.btmon_process = subprocess.Popen(cmd,
+                                              shell=False,
+                                              stdout=subprocess.PIPE,
+                                              stderr=subprocess.PIPE)
+
+    def stop(self):
+        if self.btmon_process and self.btmon_process.poll() is None:
+            self.btmon_process.send_signal(signal.SIGINT)
+            self.btmon_process.wait()
+            self.btmon_process = None


### PR DESCRIPTION
Main new features:
- many autoptsserver instances on one Windows machine
- many autoptsclient-zephyr instances on one Windows machine or Linux host
- one autoptsclient_bot on Windows machine

Note: for autoptsclient-zephyr running on Windows, download socat.exe from https://sourceforge.net/projects/unix-utils/files/socat/1.7.3.2/ and add its directory to PATH.

Example runs:

Run many instances of autoptsserver on one Windows machine like:
- in first console:
$ python autoptsserver.py
- in second console:
$ python autoptsserver.py -S 65002
- and more.

Run many autoptsclient-zephyr.py instances on one machine, for Windows it can looks like:
- in third console: (-S 65000 -C 65001 by default)
$ python ./autoptsclient-zephyr.py zephyr-master ~/zephyrproject/zephyr/tests/bluetooth/tester/build/zephyr/zephyr.elf -t COM3 -b nrf52
- in fourth console:
$ python ./autoptsclient-zephyr.py zephyr-master ~/zephyrproject/zephyr/tests/bluetooth/tester/build/zephyr/zephyr.elf -t COM4 -b nrf52 -S 65002 -C 65003
- and more.

On Linux it can looks like:
- in first console:
$ ./autoptsclient-zephyr.py zephyr-master ~/zephyrproject/zephyr/tests/bluetooth/tester/build/zephyr/zephyr.elf -i 192.168.4.2 192.168.4.2 -l 192.168.4.1 192.168.4.1 -t /dev/ttyACM0 -b nrf52
- in second console:
$ ./autoptsclient-zephyr.py zephyr-master ~/zephyrproject/zephyr/tests/bluetooth/tester/build/zephyr/zephyr.elf -i 192.168.4.2 192.168.4.2 -l 192.168.4.1 192.168.4.1 -t /dev/ttyACM1 -b nrf52  -S 65002 -C 65003

Example run of autoptsclient-zephyr for MESH testing:
- for Windows, in third console:
$ python ./autoptsclient-zephyr.py zephyr-master ~/zephyrproject/zephyr/tests/bluetooth/tester/build/zephyr/zephyr.elf -t COM3 -b nrf52 -c MESH -S 65000 65002 -C 65001 65003
- or for Linux host:
$ ./autoptsclient-zephyr.py zephyr-master ~/zephyrproject/zephyr/tests/bluetooth/tester/build/zephyr/zephyr.elf -i 192.168.4.2 192.168.4.2 -l 192.168.4.1 192.168.4.1 -t /dev/ttyACM0 -b nrf52  -c MESH -S 65000 65002 -C 65001 65003

Config for bot has new elements:
z['auto_pts'] = {
    # 'server_ip': ['192.168.3.2', '192.168.3.2'],  # uncomment for Linux host
    # 'local_ip' : ['192.168.3.1', '192.168.3.1'],  # uncomment for Linux host
    'cli_port': [65001, 65003],
    'srv_port': [65000, 65002],
    'project_path': 'C:/Users/Magda/zephyrproject/zephyr',
    'workspace': 'zephyr-master',
    'board': 'nrf52',
    'enable_max_logs': False,
    'retry': 0,
    'bd_addr': '',
}